### PR TITLE
refactor: remove createService and createDomain wrapper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ pnpm install aqua-framework
 ## Quick Start
 
 ```typescript
-import { createApp, Controller, Get, Post, createService, createDomain } from 'aqua-framework';
+import { createApp, Controller, Get, Post } from 'aqua-framework';
 
 // Domain functions
-const validateUser = createDomain((userData: any) => {
+const validateUser = (userData: any) => {
   if (!userData.name) throw new Error('Name required');
   return userData;
-});
+};
 
 // Service functions
 const userService = {
-  getAll: createService(() => [{ id: 1, name: 'John' }]),
-  create: createService((data: any) => validateUser(data))
+  getAll: () => [{ id: 1, name: 'John' }],
+  create: (data: any) => validateUser(data)
 };
 
 // Controller with static methods
@@ -91,8 +91,6 @@ pnpm test:all
 
 ## Functional Utilities
 
-- `createService()` - Service function wrapper
-- `createDomain()` - Domain function wrapper
 - `compose()` - Function composition
 - `pipe()` - Pipeline operations
 - `curry()` - Function currying

--- a/tests/e2e/test-server.ts
+++ b/tests/e2e/test-server.ts
@@ -6,7 +6,6 @@ import {
   Post, 
   Request, 
   Response, 
-  createService, 
   Interceptors,
   InterceptorFunction 
 } from '../../src/index';
@@ -39,22 +38,22 @@ const timingInterceptor: InterceptorFunction = async (context) => {
 
 // Test service
 const testService = {
-  getUsers: createService(() => [
+  getUsers: () => [
     { id: 1, name: 'John', email: 'john@example.com' },
     { id: 2, name: 'Jane', email: 'jane@example.com' }
-  ]),
+  ],
   
-  createUser: createService((userData: any) => ({
+  createUser: (userData: any) => ({
     id: Date.now(),
     ...userData,
     createdAt: new Date().toISOString()
-  })),
+  }),
 
-  getUserById: createService((id: string) => ({
+  getUserById: (id: string) => ({
     id: parseInt(id),
     name: `User ${id}`,
     email: `user${id}@example.com`
-  }))
+  })
 };
 
 // Test controller with class-level interceptor


### PR DESCRIPTION
## Summary
- Remove createService import and usage from test files
- Remove createDomain example from README
- Update service functions to use plain functions instead of wrappers
- Remove outdated functional utilities documentation

## Test plan
- [x] All unit tests pass
- [x] All E2E tests pass 
- [x] Code compiles without errors
- [x] Documentation updated to reflect changes

🤖 Generated with [Claude Code](https://claude.ai/code)